### PR TITLE
Fix broken link

### DIFF
--- a/rails_programming/routes_views_controllers_assets/views.md
+++ b/rails_programming/routes_views_controllers_assets/views.md
@@ -33,7 +33,7 @@ The first thing to note is that the named view template we render from the contr
 
 For a brand new Rails application, the `application.html.erb` layout is pretty basic.  It's got the basic tags you need in all webpages (e.g. `<html>` and `<body>`) and a couple snippets of code that load up the javascript and css files your webpage will need.  You'll want to put anything that's needed across all your webpages into the layout.  Usually this is stuff like navbars and footers and snippets of code for displaying flash messages.
 
-So if a layout is basically just a shell around the individual page, how does the page get inserted?  That brings us back to the magic of the `#yield` method, which you saw when you [learned about blocks](/ruby-programming/advanced-ruby-building-blocks).  The view template at `app/views/posts/index.html.erb` gets inserted where the yield statement is.  When you get more advanced, you'll be able to play around a bit with that statement but for now it's just that simple.
+So if a layout is basically just a shell around the individual page, how does the page get inserted?  That brings us back to the magic of the `#yield` method, which you saw when you [learned about blocks](/courses/ruby-programming/lessons/advanced-ruby-building-blocks).  The view template at `app/views/posts/index.html.erb` gets inserted where the yield statement is.  When you get more advanced, you'll be able to play around a bit with that statement but for now it's just that simple.
 
 ### Preprocessors
 


### PR DESCRIPTION
I noticed it doesn't work so instead of (/ruby-programming/advanced-ruby-building-blocks)
I put (/courses/ruby-programming/lessons/advanced-ruby-building-blocks), my guess is it should fix it :)